### PR TITLE
画像のISRを無効化

### DIFF
--- a/app/components/home/achievement/activity-achievement.tsx
+++ b/app/components/home/achievement/activity-achievement.tsx
@@ -4,15 +4,17 @@ import { getNotionDatabase } from "../../../libs/notion/notionAPI";
 import AchievementToggle from "./achievement-toggle";
 
 // ISRを使用: 60秒ごとに再生成
-export const revalidate = 60;
+export const revalidate = 0;
 
 const ActivityAchievement = async () => {
-    // 現在時刻をクエリパラメータとして追加してキャッシュを無効化
-    const timestamp = Date.now();
-    console.log(`Fetching Notion data at ${new Date(timestamp).toISOString()}`);
-    
-    const notionData = await getNotionDatabase();
-    const sortedData = notionData.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  // 現在時刻をクエリパラメータとして追加してキャッシュを無効化
+  const timestamp = Date.now();
+  console.log(`Fetching Notion data at ${new Date(timestamp).toISOString()}`);
+
+  const notionData = await getNotionDatabase();
+  const sortedData = notionData.sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+  );
   return (
     <Box py={13}>
       <Heading title="活動実績" />


### PR DESCRIPTION
## 編集
- キャッシュを無効化した

## 備考
- ISRはその期限が過ぎた後にアクセスした場合、新しいページがバックグラウンドで再ビルドされるというもの。
- 今回の場合 `const revalidate = 60` となっているので60秒後に初回アクセスした場合、裏で新しいページが再ビルドされるものの、見えているページ自体は以前のキャッシュされているものになる。
- おそらく、↑が原因じゃないかと思われる